### PR TITLE
Feat/model car service

### DIFF
--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -1,0 +1,5 @@
+class Booking < ApplicationRecord
+  belongs_to :user
+  belongs_to :car
+  belongs_to :service
+end

--- a/app/models/car.rb
+++ b/app/models/car.rb
@@ -1,0 +1,2 @@
+class Car < ApplicationRecord
+end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,0 +1,2 @@
+class Service < ApplicationRecord
+end

--- a/db/migrate/20250719002127_create_cars.rb
+++ b/db/migrate/20250719002127_create_cars.rb
@@ -1,0 +1,11 @@
+class CreateCars < ActiveRecord::Migration[7.0]
+  def change
+    create_table :cars do |t|
+      t.string :make
+      t.string :model
+      t.string :rego
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250719002218_create_services.rb
+++ b/db/migrate/20250719002218_create_services.rb
@@ -1,0 +1,9 @@
+class CreateServices < ActiveRecord::Migration[7.0]
+  def change
+    create_table :services do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250719002241_create_bookings.rb
+++ b/db/migrate/20250719002241_create_bookings.rb
@@ -1,0 +1,13 @@
+class CreateBookings < ActiveRecord::Migration[7.0]
+  def change
+    create_table :bookings do |t|
+      t.date :date
+      t.string :status
+      t.references :user, null: false, foreign_key: true
+      t.references :car, null: false, foreign_key: true
+      t.references :service, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,36 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_27_015053) do
+ActiveRecord::Schema[7.0].define(version: 2025_07_19_002241) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "bookings", force: :cascade do |t|
+    t.date "date"
+    t.string "status"
+    t.bigint "user_id", null: false
+    t.bigint "car_id", null: false
+    t.bigint "service_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["car_id"], name: "index_bookings_on_car_id"
+    t.index ["service_id"], name: "index_bookings_on_service_id"
+    t.index ["user_id"], name: "index_bookings_on_user_id"
+  end
+
+  create_table "cars", force: :cascade do |t|
+    t.string "make"
+    t.string "model"
+    t.string "rego"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "services", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -28,4 +55,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_27_015053) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "bookings", "cars"
+  add_foreign_key "bookings", "services"
+  add_foreign_key "bookings", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,14 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+
+Car.create!([
+  { make: "Toyota", model: "Corolla", rego: "ABC123" },
+  { make: "Ford", model: "Ranger", rego: "XYZ789" }
+])
+
+Service.create!([
+  { name: "Maintenance" },
+  { name: "WOF" },
+  { name: "Detailing" }
+])


### PR DESCRIPTION
## ✨ Summary

This PR adds the foundational data models and seed data for the Fleet Booking API. It includes:

- `Car` model with `make`, `model`, and `rego`
- `Service` model with `name`
- `Booking` model with `date`, `status`, and references to `User`, `Car`, and `Service`
- Seed data for Cars and Services to support dropdowns in the frontend

---

## 📦 What’s Included

- `Car`, `Service`, and `Booking` models
- Associated migrations and relationships
- Seed data for 2 cars and 3 services
- Ran `rails db:migrate` and `rails db:seed`

---

## 🧪 How to Test

```bash
rails db:migrate db:seed
```

- Check the database using `rails console` to confirm:
  - 2 `Car` records
  - 3 `Service` records
- Models and schema should reflect relationships above

---

## 📌 Next Steps

- Add `BookingsController` and endpoints
- Enable booking creation and listing
- Hook up mailer for booking confirmation
-  Model Relationships:
> - `User has_many :bookings`
> - `Booking belongs_to :user`
> - `Booking belongs_to :car`
> - `Booking belongs_to :service`